### PR TITLE
Yeoman 1.5.0 support 

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -57,17 +57,17 @@ NpLaravelGenerator.prototype.animateLogo = function () {
   var cb = this.async();
   this.log.write();
   var count = 35;
-  var no = '\r   NO'.bold;
-  var protocol = 'PROTOCOL'.magenta.bold;
+  var no = '\r   NO';
+  var protocol = 'PROTOCOL';
   var self = this;
   var animate = function () {
-    self.log.write(no + (new Array(count).join(' ')) + protocol + ':// '.bold);
+    self.log.write(no + (new Array(count).join(' ')) + protocol + ':// ');
     count--;
     if (count === 0) {
       setTimeout(function () {
         self.log.write(no + protocol + ';// ');
         setTimeout(function () {
-          self.log.write(no + protocol + ':// '.bold);
+          self.log.write(no + protocol + ':// ');
           setTimeout(function () {
             self.log.write('\n\n');
             cb();

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "mocha": "~2.2.4"
   },
   "peerDependencies": {
-    "yo": ">=1.4.6"
   },
   "engines": {
     "node": ">=0.8.0",


### PR DESCRIPTION
Installing this generator whilst having yeoman 1.5.0 installed shows this warning:

```
npm WARN EPEERINVALID generator-np-laravel@2.1.4
requires a peer of yo@>=1.4.6 but none was installed.
```

Which is weird because 1.5.0>=1.4.6. Solved by removing `yo` from `peerDependencies`, However i am not sure what the consequences are.

Also that it seems that `chalk` or it's dependency `ansi-styles` isn't working properly anymore. The `bold` and `magento` function are returning errors, i removed them for now.

```
events.js:141
      throw er; // Unhandled 'error' event
      ^

TypeError: Cannot read property 'bold' of undefined
    at NpLaravelGenerator.animateLogo (/Users/bjorn/generator-np-laravel/app/index.js:61:36)
    at /Users/bjorn/generator-np-laravel/node_modules/yeoman-generator/lib/base.js:421:16
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

@gverschuur Can you check if these quick fixes are OK to merge or we should spend a little more time to fix them properly?
